### PR TITLE
Overriding global variable fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,17 +18,17 @@ const SEPARATOR = ' / ';
  * @private
  */
 function getParentName (item, separator) {
-    if (_.isEmpty(item) || !_.isFunction(item.parent) || !_.isFunction(item.forEachParent)) { 
+	if (_.isEmpty(item) || !_.isFunction(item.parent) || !_.isFunction(item.forEachParent)) { 
 		return; 
 	}
 
-    var chain = [];
+	var chain = [];
 	
-    item.forEachParent(function (parent) { 
+	item.forEachParent(function (parent) { 
 		chain.unshift(parent.name || parent.id); 
 	});
 	
-    return chain.join(_.isString(separator) ? separator : SEPARATOR);
+	return chain.join(_.isString(separator) ? separator : SEPARATOR);
 }
 
 /**
@@ -49,11 +49,11 @@ JunitFullReporter = function (newman, reporterOptions, options) {
 		
 		var date = moment(new Date()).local().format('YYYY-MM-DDTHH:mm:ss.SSS');
 
-        if (!executions) {
-            return;
-        }
+		if (!executions) {
+			return;
+		}
 
-        root = xml.create('testsuites', { version: '1.0', encoding: 'UTF-8' });
+		root = xml.create('testsuites', { version: '1.0', encoding: 'UTF-8' });
 
 		// Process executions (testsuites)
 		_.forEach(executions, function (execution) {
@@ -61,7 +61,7 @@ JunitFullReporter = function (newman, reporterOptions, options) {
 			var failures = 0, errors = 0;
 			var propertyValues = _.merge(environmentValues, globalValues);
 				
-            testsuite.att('id', (execution.cursor.iteration * execution.cursor.length) + execution.cursor.position);
+			testsuite.att('id', (execution.cursor.iteration * execution.cursor.length) + execution.cursor.position);
 			
 			// Hostname
 			var protocol = _.get(execution, 'request.url.protocol', 'https') + '://';
@@ -158,18 +158,18 @@ JunitFullReporter = function (newman, reporterOptions, options) {
 			});
 		});
 		
-        newman.exports.push({
-            name: 'junit-reporter-full',
-            default: 'newman-run-report-full.xml',
-            path: reporterOptions.export,
-            content: root.end({
-                pretty: true,
-                indent: '  ',
-                newline: '\n',
-                allowEmpty: false
-            })
-        });
-    });
+		newman.exports.push({
+			name: 'junit-reporter-full',
+			default: 'newman-run-report-full.xml',
+			path: reporterOptions.export,
+			content: root.end({
+			pretty: true,
+			indent: '  ',
+			newline: '\n',
+			allowEmpty: false
+			})
+		});
+	});
 };
 
 module.exports = JunitFullReporter;

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,11 +52,11 @@ JunitFullReporter = function (newman, reporterOptions, options) {
             return;
         }
 
-        global = xml.create('testsuites', { version: '1.0', encoding: 'UTF-8' });
+        root = xml.create('testsuites', { version: '1.0', encoding: 'UTF-8' });
 
 		// Process executions (testsuites)
 		_.forEach(executions, function (execution) {
-			var testsuite = global.ele('testsuite');
+			var testsuite = root.ele('testsuite');
 			var failures = 0, errors = 0;
 			var propertyValues = _.merge(environmentValues, globalValues);
 				
@@ -161,7 +161,7 @@ JunitFullReporter = function (newman, reporterOptions, options) {
             name: 'junit-reporter-full',
             default: 'newman-run-report-full.xml',
             path: reporterOptions.export,
-            content: global.end({
+            content: root.end({
                 pretty: true,
                 indent: '  ',
                 newline: '\n',

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,9 +42,10 @@ function getParentName (item, separator) {
 JunitFullReporter = function (newman, reporterOptions, options) {
     
 	newman.on('beforeDone', function () {
-        var executions = _.get(newman, 'summary.run.executions'),
-		globalValues = _.get(newman, 'summary.globals.values.members', []),
-		environmentValues = _.get(newman, 'summary.environment.values.members', []);
+		var executions = _.get(newman, 'summary.run.executions'),
+		    globalValues = _.get(newman, 'summary.globals.values.members', []),
+		    environmentValues = _.get(newman, 'summary.environment.values.members', []),
+		    root;
 		
 		var date = moment(new Date()).local().format('YYYY-MM-DDTHH:mm:ss.SSS');
 


### PR DESCRIPTION
Changing 'global' variable to local 'root'. 
Reason: 'global' is node.js global namespace object and overwriting it causes problems, for example in newman/lib/run/secure-fs.js in line 'this.isWindows = global.process.platform === 'win32';'