### PR TITLE
Fix issue #5 show proper error(s) and failure(s) count per testsuite.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,7 +137,7 @@ JunitFullReporter = function (newman, reporterOptions, options) {
 						var result;
 						if (property !== 'assertions') {
 							// Error
-							++errors;
+							testsuite.att('errors', ++errors);
 							result = testcase.ele('error');
 							
 							if (errorItem.stacktrace) {
@@ -145,7 +145,7 @@ JunitFullReporter = function (newman, reporterOptions, options) {
 							}
 						} else {
 							// Failure
-							++failures;
+							testsuite.att('failures', ++failures);
 							result = testcase.ele('failure');
 							result.dat(errorItem.stack);
 						}


### PR DESCRIPTION
Simple fix to get the error(s) and failure(s) count per testsuite right.